### PR TITLE
Update QuestManager.cs

### DIFF
--- a/apps/server/Managers/QuestManager.cs
+++ b/apps/server/Managers/QuestManager.cs
@@ -277,7 +277,7 @@ public class QuestManager
             return;
         }
 
-        if (quest.NumTimesCompleted > 3)
+        if (quest.NumTimesCompleted > 5)
         {
             return;
         }
@@ -301,8 +301,10 @@ public class QuestManager
         var level = quest.NumTimesCompleted switch
         {
             1 => "slight",
-            2 => "moderate",
-            3 => "significant",
+            2 => "minor",
+            3 => "moderate",
+            4 => "major",
+            5 => "significant",
             _ => ""
         };
 
@@ -313,8 +315,14 @@ public class QuestManager
             )
         );
 
-        if (quest.NumTimesCompleted == 3)
-        {
+    if (quest.NumTimesCompleted == 5)
+    {
+        player.Session.Network.EnqueueSend(
+            new GameMessageSystemChat(
+                $"A final shift runs through you as the portal energy of {townName} stabilizes and stops pressing against you.",
+                ChatMessageType.System
+            )
+        );
             player.PlayParticleEffect(PlayScript.PortalStorm, player.Guid);
         }
     }


### PR DESCRIPTION
Modified to manage 5 stamps.
5 separate messages and a final message:
8:17:52 Tempered by the portal energies of Arwic, a slight resilience has taken shape within you. 8:17:52 QuestArwic stamped with 1 completions.
8:17:53 Tempered by the portal energies of Arwic, a minor resilience has taken shape within you. 8:17:53 QuestArwic stamped with 2 completions.
8:17:54 Tempered by the portal energies of Arwic, a moderate resilience has taken shape within you. 8:17:54 QuestArwic stamped with 3 completions.
8:17:55 Tempered by the portal energies of Arwic, a major resilience has taken shape within you. 8:17:55 QuestArwic stamped with 4 completions.
8:17:56 Tempered by the portal energies of Arwic, a significant resilience has taken shape within you. 8:17:56 A final shift runs through you as the portal energy of Arwic stabilizes and stops pressing against you. 8:17:56 QuestArwic stamped with 5 completions.