### PR TITLE
Add shroud zone configuration handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -301,6 +301,8 @@ __pycache__/
 
 # ACEmulator specific folders
 Config/
+!apps/server/Config/
+!apps/server/Config/*.cs
 Dats/
 Logs/
 db-data/

--- a/apps/server-tests/ShroudZoneConfigTests.cs
+++ b/apps/server-tests/ShroudZoneConfigTests.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using ACE.Server.Config;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ACE.Server.Tests;
+
+[TestClass]
+public class ShroudZoneConfigTests
+{
+    [TestMethod]
+    public void ParsesValidEntries()
+    {
+        var raw = "0xD2A80024 [100.684067 87.626068 20.004999] 0.015540 0.000000 0.000000 0.999879|10|40";
+        var config = new ShroudZoneConfig(raw);
+
+        Assert.AreEqual(1, config.Zones.Count);
+
+        var zone = config.Zones.Single();
+        Assert.AreEqual((uint)0xD2A8, zone.Landblock);
+        Assert.AreEqual(10f, zone.Radius);
+        Assert.AreEqual(40f, zone.MaxDistance);
+        Assert.AreEqual(100.684067f, zone.Center.PositionX, 0.0001f);
+        Assert.AreEqual(87.626068f, zone.Center.PositionY, 0.0001f);
+        Assert.AreEqual(20.004999f, zone.Center.PositionZ, 0.0001f);
+    }
+
+    [TestMethod]
+    public void IgnoresInvalidEntries()
+    {
+        var raw = "invalid entry that should be skipped";
+        var config = new ShroudZoneConfig(raw);
+
+        Assert.AreEqual(0, config.Zones.Count);
+    }
+}

--- a/apps/server/Config/ShroudZoneConfig.cs
+++ b/apps/server/Config/ShroudZoneConfig.cs
@@ -1,0 +1,211 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using ACE.Entity;
+using ACE.Server.Managers;
+using Serilog;
+
+namespace ACE.Server.Config;
+
+public class ShroudZoneConfig
+{
+    public const string PropertyKey = "shroud_zone_entries";
+
+    private static readonly ILogger Log = Serilog.Log.ForContext<ShroudZoneConfig>();
+
+    public ShroudZoneConfig(string rawEntries)
+    {
+        Zones = Parse(rawEntries);
+    }
+
+    public IReadOnlyList<ShroudZoneEntry> Zones { get; }
+
+    public static ShroudZoneConfig FromProperties()
+    {
+        var property = PropertyManager.GetString(PropertyKey, string.Empty);
+        return new ShroudZoneConfig(property.Item);
+    }
+
+    private static IReadOnlyList<ShroudZoneEntry> Parse(string rawEntries)
+    {
+        var zones = new List<ShroudZoneEntry>();
+
+        if (string.IsNullOrWhiteSpace(rawEntries))
+        {
+            return zones;
+        }
+
+        var lines = rawEntries
+            .Split(new[] { '\n', ';' }, System.StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.Trim())
+            .Where(l => !string.IsNullOrWhiteSpace(l));
+
+        foreach (var line in lines)
+        {
+            if (TryParseEntry(line, out var entry))
+            {
+                zones.Add(entry);
+            }
+        }
+
+        return zones;
+    }
+
+    private static bool TryParseEntry(string line, out ShroudZoneEntry entry)
+    {
+        entry = null;
+
+        // Expected format: "<cellHex> [<x> <y> <z>] <qx> <qy> <qz> <qw>|<radius>|<maxDistance>"
+        var segments = line.Split('|', System.StringSplitOptions.RemoveEmptyEntries | System.StringSplitOptions.TrimEntries);
+        if (segments.Length < 3)
+        {
+            Log.Warning("Unable to parse shroud zone entry (missing segments): {Entry}", line);
+            return false;
+        }
+
+        if (!TryParsePosition(segments[0], out var center))
+        {
+            Log.Warning("Unable to parse shroud zone position: {Entry}", line);
+            return false;
+        }
+
+        if (!float.TryParse(segments[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var radius) || radius <= 0)
+        {
+            Log.Warning("Unable to parse shroud zone radius: {Entry}", line);
+            return false;
+        }
+
+        if (!float.TryParse(segments[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var maxDistance)
+            || maxDistance <= 0)
+        {
+            Log.Warning("Unable to parse shroud zone ejection distance: {Entry}", line);
+            return false;
+        }
+
+        entry = new ShroudZoneEntry(center, radius, maxDistance);
+        return true;
+    }
+
+    private static bool TryParsePosition(string raw, out Position position)
+    {
+        position = null;
+
+        var trimmed = raw.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            return false;
+        }
+
+        var firstSpace = trimmed.IndexOf(' ');
+        if (firstSpace <= 0)
+        {
+            return false;
+        }
+
+        var cellToken = trimmed[..firstSpace];
+        uint cellId;
+        if (cellToken.StartsWith("0x"))
+        {
+            if (!uint.TryParse(cellToken[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out cellId))
+            {
+                return false;
+            }
+        }
+        else if (!uint.TryParse(cellToken, NumberStyles.Integer, CultureInfo.InvariantCulture, out cellId))
+        {
+            return false;
+        }
+
+        var startBracket = trimmed.IndexOf('[', firstSpace);
+        var endBracket = trimmed.IndexOf(']', startBracket + 1);
+        if (startBracket < 0 || endBracket < 0)
+        {
+            return false;
+        }
+
+        var coordinateSegment = trimmed.Substring(startBracket + 1, endBracket - startBracket - 1);
+        var coords = coordinateSegment.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+        if (coords.Length != 3)
+        {
+            return false;
+        }
+
+        if (!TryParseVector3(coords, out var positionVec))
+        {
+            return false;
+        }
+
+        var rotationSegment = trimmed[(endBracket + 1)..].Trim();
+        var rotationTokens = rotationSegment.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+        if (rotationTokens.Length < 4)
+        {
+            return false;
+        }
+
+        if (!TryParseQuaternion(rotationTokens, out var rotation))
+        {
+            return false;
+        }
+
+        position = new Position(cellId, positionVec, rotation);
+        return true;
+    }
+
+    private static bool TryParseVector3(string[] tokens, out Vector3 vector)
+    {
+        vector = Vector3.Zero;
+        if (
+            tokens.Length != 3
+            || !float.TryParse(tokens[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var x)
+            || !float.TryParse(tokens[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var y)
+            || !float.TryParse(tokens[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var z)
+        )
+        {
+            return false;
+        }
+
+        vector = new Vector3(x, y, z);
+        return true;
+    }
+
+    private static bool TryParseQuaternion(string[] tokens, out Quaternion quaternion)
+    {
+        quaternion = Quaternion.Identity;
+        if (
+            tokens.Length < 4
+            || !float.TryParse(tokens[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var qx)
+            || !float.TryParse(tokens[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var qy)
+            || !float.TryParse(tokens[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var qz)
+            || !float.TryParse(tokens[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var qw)
+        )
+        {
+            return false;
+        }
+
+        quaternion = new Quaternion(qx, qy, qz, qw);
+        return true;
+    }
+}
+
+public class ShroudZoneEntry
+{
+    public ShroudZoneEntry(Position center, float radius, float maxDistance)
+    {
+        Center = center;
+        Radius = radius;
+        MaxDistance = maxDistance;
+        Landblock = center.Landblock;
+        RadiusSquared = radius * radius;
+    }
+
+    public Position Center { get; }
+
+    public float Radius { get; }
+
+    public float MaxDistance { get; }
+
+    public uint Landblock { get; }
+
+    public float RadiusSquared { get; }
+}

--- a/apps/server/Managers/PropertyManager.cs
+++ b/apps/server/Managers/PropertyManager.cs
@@ -879,6 +879,7 @@ public static class DefaultPropertyManager
         ("popup_welcome", new Property<string>("To begin your training, speak to the Society Greeter. Walk up to the Society Greeter using the 'W' key, then double-click on her to initiate a conversation.", "Welcome message popup in training halls")),
         ("popup_welcome_olthoi", new Property<string>("Welcome to the Olthoi hive! Be sure to talk to the Olthoi Queen to receive the Olthoi protections granted by the energies of the hive.", "Welcome message displayed on the first login for an Olthoi Player")),
         ("popup_motd", new Property<string>("", "Popup message of the day")),
-        ("server_motd", new Property<string>("", "Server message of the day"))
+        ("server_motd", new Property<string>("", "Server message of the day")),
+        ("shroud_zone_entries", new Property<string>("", "Shroud zones defined as '<cell> [x y z] qx qy qz qw|radius|maxDistance' separated by newlines or semicolons"))
     );
 }

--- a/apps/server/WorldObjects/Managers/ShroudZoneService.cs
+++ b/apps/server/WorldObjects/Managers/ShroudZoneService.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Numerics;
+using ACE.Server.Config;
+using ACE.Server.Entity;
+using ACE.Server.Managers;
+using ACE.Server.WorldObjects;
+using ACE.Server.Network.Enum;
+using Serilog;
+
+namespace ACE.Server.WorldObjects.Managers;
+
+public class ShroudZoneService
+{
+    private static readonly ILogger Log = Serilog.Log.ForContext<ShroudZoneService>();
+
+    private static readonly TimeSpan Cooldown = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan TeleportCooldown = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan MinShroudedDelay = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan MaxShroudedDelay = TimeSpan.FromMinutes(5);
+
+    private readonly ConcurrentDictionary<ObjectGuid, ZonePlayerState> _playerStates = new();
+    private readonly IReadOnlyDictionary<uint, List<ShroudZoneEntry>> _zonesByLandblock;
+
+    public ShroudZoneService(ShroudZoneConfig config)
+    {
+        _zonesByLandblock = BuildLookup(config.Zones);
+        Log.Information("Loaded {ZoneCount} shroud zone entries", config.Zones.Count);
+    }
+
+    public static ShroudZoneService CreateFromConfig()
+    {
+        var config = ShroudZoneConfig.FromProperties();
+        return new ShroudZoneService(config);
+    }
+
+    public bool TryHandlePlayer(Player player)
+    {
+        if (_zonesByLandblock.Count == 0)
+        {
+            return false;
+        }
+
+        var location = player?.Location;
+        if (location == null)
+        {
+            return false;
+        }
+
+        if (!_zonesByLandblock.TryGetValue(location.Landblock, out var zones))
+        {
+            return false;
+        }
+
+        var now = DateTime.UtcNow;
+        var state = _playerStates.GetOrAdd(player.Guid, _ => new ZonePlayerState());
+
+        foreach (var zone in zones)
+        {
+            if (!IsInside(location, zone))
+            {
+                continue;
+            }
+
+            if (state.NextAllowedActionUtc > now)
+            {
+                return false;
+            }
+
+            if (player.IsShrouded())
+            {
+                ScheduleOrTriggerShroudedEffect(player, zone, state, now);
+                _playerStates[player.Guid] = state;
+                return false;
+            }
+
+            ExecuteTeleport(player, zone, now, state);
+            _playerStates[player.Guid] = state;
+            return true;
+        }
+
+        if (state.PendingEffectUtc.HasValue)
+        {
+            state.PendingEffectUtc = null;
+            _playerStates[player.Guid] = state;
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyDictionary<uint, List<ShroudZoneEntry>> BuildLookup(IReadOnlyList<ShroudZoneEntry> zones)
+    {
+        var result = new Dictionary<uint, List<ShroudZoneEntry>>();
+
+        foreach (var zone in zones)
+        {
+            if (!result.TryGetValue(zone.Landblock, out var list))
+            {
+                list = new List<ShroudZoneEntry>();
+                result[zone.Landblock] = list;
+            }
+
+            list.Add(zone);
+        }
+
+        return result;
+    }
+
+    private static bool IsInside(ACE.Entity.Position location, ShroudZoneEntry zone)
+    {
+        var distanceSq = Vector3.DistanceSquared(location.Pos, zone.Center.Pos);
+        return distanceSq <= zone.RadiusSquared;
+    }
+
+    private void ScheduleOrTriggerShroudedEffect(Player player, ShroudZoneEntry zone, ZonePlayerState state, DateTime now)
+    {
+        if (state.PendingEffectUtc.HasValue)
+        {
+            if (now >= state.PendingEffectUtc.Value)
+            {
+                player.PlayParticleEffect(PlayScript.PortalEntry, player.Guid);
+                state.PendingEffectUtc = null;
+                state.NextAllowedActionUtc = now + Cooldown;
+                Log.Debug(
+                    "Played shrouded zone swirl for {Player} in landblock {Landblock}",
+                    player.Name,
+                    zone.Landblock
+                );
+            }
+
+            return;
+        }
+
+        var delaySeconds = Random.Shared.NextDouble() * (MaxShroudedDelay - MinShroudedDelay).TotalSeconds
+            + MinShroudedDelay.TotalSeconds;
+        var delay = TimeSpan.FromSeconds(delaySeconds);
+
+        state.PendingEffectUtc = now + delay;
+        state.NextAllowedActionUtc = state.PendingEffectUtc.Value;
+        Log.Debug(
+            "Scheduled shrouded zone swirl for {Player} in landblock {Landblock} after {Delay} seconds",
+            player.Name,
+            zone.Landblock,
+            delay.TotalSeconds
+        );
+    }
+
+    private void ExecuteTeleport(Player player, ShroudZoneEntry zone, DateTime now, ZonePlayerState state)
+    {
+        var destination = BuildDestination(zone, player);
+
+        player.PlayParticleEffect(PlayScript.PortalEntry, player.Guid);
+        WorldManager.ThreadSafeTeleport(player, destination);
+
+        state.PendingEffectUtc = null;
+        state.NextAllowedActionUtc = now + TeleportCooldown;
+        Log.Information(
+            "Teleported {Player} away from shroud zone in landblock {Landblock} after entering radius {Radius}",
+            player.Name,
+            zone.Landblock,
+            zone.Radius
+        );
+    }
+
+    private static ACE.Entity.Position BuildDestination(ShroudZoneEntry zone, Player player)
+    {
+        var angle = Random.Shared.NextDouble() * Math.Tau;
+        var minDistance = zone.Radius;
+        var maxDistance = Math.Max(minDistance + 1, zone.MaxDistance);
+        var distance = minDistance + (float)(Random.Shared.NextDouble() * (maxDistance - minDistance));
+
+        var offsetX = (float)Math.Cos(angle) * distance;
+        var offsetY = (float)Math.Sin(angle) * distance;
+
+        var newPos = new Vector3(zone.Center.PositionX + offsetX, zone.Center.PositionY + offsetY, zone.Center.PositionZ);
+        var destination = new ACE.Entity.Position(zone.Center.LandblockId.Raw, newPos, player.Location.Rotation);
+
+        WorldObject.AdjustDungeon(destination);
+        return destination;
+    }
+
+    private class ZonePlayerState
+    {
+        public DateTime NextAllowedActionUtc { get; set; }
+
+        public DateTime? PendingEffectUtc { get; set; }
+    }
+}

--- a/apps/server/WorldObjects/Player_Tick.cs
+++ b/apps/server/WorldObjects/Player_Tick.cs
@@ -14,11 +14,14 @@ using ACE.Server.Network.Motion;
 using ACE.Server.Network.Sequence;
 using ACE.Server.Physics;
 using ACE.Server.Physics.Common;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.WorldObjects;
 
 partial class Player
 {
+    private static readonly ShroudZoneService ShroudZoneService = ShroudZoneService.CreateFromConfig();
+
     private readonly ActionQueue actionQueue = new ActionQueue();
 
     private int initialAge;
@@ -405,6 +408,8 @@ partial class Player
         //Console.WriteLine($"{PhysicsObj.Position.Frame.get_heading()}");
 
         PhysicsObj.update_object();
+
+        ShroudZoneService.TryHandlePlayer(this);
 
         // sync ace position?
         Location.Rotation = PhysicsObj.Position.Frame.Orientation;


### PR DESCRIPTION
## Summary
- add a configurable `shroud_zone_entries` server property and parsing options class for shroud zone definitions
- introduce a shroud zone service that enforces cooldowns, particle effects, and safe teleport handling based on player state
- hook the service into player physics updates and add unit coverage for the configuration parser while allowing the config folder to be tracked

## Testing
- `dotnet test` *(fails: `dotnet` command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692af311df3483329d22f2340b7251d1)